### PR TITLE
[ci skip] adding user @jessemapel

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @AndrewAnnex
+* @jessemapel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,4 +44,5 @@ about:
     
 extra:
     recipe-maintainers:
+      - jessemapel
       - AndrewAnnex


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @jessemapel as instructed in #2.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #2